### PR TITLE
マルチコア環境で劇的に重かった問題の解決。shared_ptr<>が関数の入出力に入っておりそこで時間を大量に消費していた。

### DIFF
--- a/src/app/alhazen.cpp
+++ b/src/app/alhazen.cpp
@@ -9,6 +9,7 @@
 #include "core/util.hpp"
 #include "core/parallelfor.hpp"
 #include "core/stats.hpp"
+#include "core/floatstreamstats.hpp"
 
 /*
 -------------------------------------------------
@@ -39,6 +40,8 @@ Alhazen::runApp(const ArgConfig& config)
     uint32_t nextDevelopTime =
       g_timeUtil.elapseTimeInMs() + developIntervalInMs;
     uint32_t nextStatPrintTime = g_timeUtil.elapseTimeInMs() + 1000;
+    //
+    FloatStreamStats taskTimeStats;
 
     for (;;) {
         //
@@ -93,10 +96,11 @@ Alhazen::runApp(const ArgConfig& config)
               //
               CounterStats::postParallel();
           });
+        taskTimeStats.add(float(g_timeUtil.elapseTimeInMs() - startRenderTime));
         logging("Render Task pushed (%08d->%08d) %d ms",
                 taskNo,
                 taskNo + TASK_NUM_UNTILL_BY_JOIN,
-                g_timeUtil.elapseTimeInMs() - startRenderTime);
+                int32_t(taskTimeStats.mean()));
         //
         taskNo += TASK_NUM_UNTILL_BY_JOIN;
     }

--- a/src/core/ray.hpp
+++ b/src/core/ray.hpp
@@ -109,7 +109,7 @@ public:
     Vec3 normal = Vec3(1.0f, 0.0f, 0.0);
     Vec3 position = Vec3(0.0f);
     Vec2 uv = Vec2(0.0f, 0.0f);
-    BSDFPtr bsdf = nullptr;
+    BSDF* bsdf = nullptr;
     // 交差点でのEmission
     Spectrum emission = Spectrum::Black;
     // 交差したオブジェクト

--- a/src/integrator/bruteforce.cpp
+++ b/src/integrator/bruteforce.cpp
@@ -94,7 +94,7 @@ BruteForceIntegrator::radiance(const Ray& screenRay,
             lighting += isect.emission * throughput;
         }
         //
-        const BSDFPtr bsdf = isect.bsdf;
+        const BSDF* bsdf = isect.bsdf;
         Vec3 localWi;
         const OrthonormalBasis<> local(isect.normal);
         const Vec3 localWo = local.world2local(-ray.d);

--- a/src/light/light.cpp
+++ b/src/light/light.cpp
@@ -132,7 +132,7 @@ ConstantLight::intersect(const Ray& ray, Intersect* isect) const
     // ConstantLightは常に衝突対象
     isect->t = lightFar;
     isect->normal = -ray.d;
-    isect->bsdf = BSDF::vantaBlack; // NOTE: 常に反射率0
+    isect->bsdf = BSDF::vantaBlack.get(); // NOTE: 常に反射率0
     isect->emission = spectrum_;
     return true;
 }
@@ -388,7 +388,7 @@ RectangleLight::intersect(const Ray& ray, Intersect* isect) const
                                uvs_[3],
                                isect);
     if (isHit) {
-        isect->bsdf = BSDF::vantaBlack;
+        isect->bsdf = BSDF::vantaBlack.get();
         isect->emission = spectrum_;
     }
     return isHit;
@@ -680,7 +680,7 @@ SphereLight::intersect(const Ray& ray, Intersect* isect) const
 {
     const bool hit = intersectSphere(ray, center_, radius2_, isect);
     if (hit) {
-        isect->bsdf = BSDF::vantaBlack;
+        isect->bsdf = BSDF::vantaBlack.get();
         isect->emission = emission_;
     }
     return hit;

--- a/src/shape/meshShape.cpp
+++ b/src/shape/meshShape.cpp
@@ -99,7 +99,7 @@ ObjShape::intersect(const Ray& ray, Intersect* isect) const
 {
     int8_t materialId = 0;
     if (bvh_.intersect(ray, isect, &materialId)) {
-        isect->bsdf = bsdfs_[materialId];
+        isect->bsdf = bsdfs_[materialId].get();
         return true;
     }
     return false;

--- a/src/shape/primitive.cpp
+++ b/src/shape/primitive.cpp
@@ -261,7 +261,7 @@ RectangleShape::intersect(const Ray& ray, Intersect* isect) const
     if (!hit0 && !hit1) {
         return false;
     }
-    isect->bsdf = bsdf_;
+    isect->bsdf = bsdf_.get();
     return true;
 }
 
@@ -341,7 +341,7 @@ bool
 Sphere::intersect(const Ray& ray, Intersect* isect) const
 {
     if (intersectSphere(ray, pos_, r2_, isect)) {
-        isect->bsdf = bsdf_;
+        isect->bsdf = bsdf_.get();
         return true;
     }
     return false;


### PR DESCRIPTION
- マルチコア環境で劇的に重かった問題の解決。shared_ptr<>が関数の入出力に入っておりそこで時間を大量に消費していた。
- タスクの経過時間を安定してとれるようにする。