### PR TITLE
objファイルをまた読めるように。

### DIFF
--- a/src/core/util.cpp
+++ b/src/core/util.cpp
@@ -10,11 +10,10 @@ FileSystem g_fileSystem;
 void FileSystem::init(const char* sceneFilePath, const char* exeFilePath)
 {
     // 出力フォルダを作成する
-    std::string sceneFileDir;
     std::string fileName;
-    getDirPath(sceneFilePath, sceneFileDir, fileName);
+    getDirPath(sceneFilePath, sceneFileDir_, fileName);
     // ディレクトリ作成作成
-    outputDir_ = sceneFileDir + "/output/";
+    outputDir_ = sceneFileDir_ + "/output/";
 #if defined(WINDOWS)
     _mkdir(outputDir_.c_str());
 #else
@@ -32,7 +31,6 @@ void FileSystem::init(const char* sceneFilePath, const char* exeFilePath)
 
 /*
 -------------------------------------------------
-
 -------------------------------------------------
 */
 std::string FileSystem::getOutputFolderPath() const
@@ -47,6 +45,12 @@ std::string FileSystem::getOutputFolderPath() const
         return exeDir_;
     }
 }
+
+/*
+-------------------------------------------------
+-------------------------------------------------
+*/
+std::string FileSystem::getSceneFileFolderPath() const { return sceneFileDir_; }
 
 /*
 -------------------------------------------------

--- a/src/core/util.hpp
+++ b/src/core/util.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "pch.hpp"
 
@@ -11,6 +11,7 @@ class FileSystem AL_FINAL
 public:
     void init(const char* sceneFilePath, const char* exeFilePath);
     std::string getOutputFolderPath() const;
+    std::string getSceneFileFolderPath() const;
     //
     static const char* getExt(const char* fileName);
     static void getDirPath(const std::string& fullPath,
@@ -19,6 +20,7 @@ public:
     static std::string readTextFileAll(const std::string& filePath);
 
 private:
+    std::string sceneFileDir_;
     std::string outputDir_;
     std::string exeDir_;
 };

--- a/src/shape/meshShape.cpp
+++ b/src/shape/meshShape.cpp
@@ -3,6 +3,7 @@
 #include "core/transform.hpp"
 #include "shape/shape.hpp"
 #include "accelerator/bvh.hpp"
+#include "core/util.hpp"
 
 /*
 -------------------------------------------------
@@ -35,12 +36,12 @@ REGISTER_OBJECT(Shape, ObjShape);
 ObjShape::ObjShape(const ObjectProp& objectProp) : Shape(objectProp)
 {
     const std::string fileName =
-        objectProp.findChildBy("name", "filename").asString("test.obj");
+        objectProp.findChildByTag("filename").asString("test.obj");
     const Transform transform(objectProp.findChildByTag("transform"));
     twosided_ = objectProp.findChildBy("name", "twosided").asBool(false);
     // meshのロード
     Mesh mesh;
-    mesh.loadFromoObj(fileName);
+    mesh.loadFromoObj(g_fileSystem.getSceneFileFolderPath() + fileName);
     mesh.applyTransform(transform);
     // mesh.recalcNormal();
     // mesh.recalcBound();


### PR DESCRIPTION
- objに空行が入っている場合に扱えていなかったのを修正
- scenefilepath取得を追加し、相対パスにあるobjファイルをロードできるように。